### PR TITLE
chore(dependabot): group dependabot upgrade PRs to minimize spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,13 +15,23 @@ updates:
       github-actions-deps:
         patterns:
           - "*"
-  - package-ecosystem: docker
-    directory: /
+  - package-ecosystem: "docker"
+    directory: /docker
     schedule:
-      interval: weekly
+      interval: "weekly"
     assignees:
       - ajhalili2006
     groups:
       docker-base-images:
+        patterns:
+          - "*"
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - ajhalili2006
+    groups:
+      devcontainers-stuff:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,27 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
- - package-ecosystem: "github-actions"
-   directory: /
-   schedule:
-     interval: weekly
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    assignees:
+      - ajhalili2006
+    groups:
+      github-actions-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - ajhalili2006
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"


### PR DESCRIPTION
Instead of having separate Dependabot upgrade PRs for each dependency, we'll group them by package ecosystem for maintainability reasons as well as to minimize spam.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/recaptime-dev/proxyparty-caddy/6)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration: reorganized and grouped GitHub Actions, Docker base-image, and devcontainer update sets for clearer management.
  * Standardized scheduling format and reformatted update blocks for consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->